### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,12 @@ YoYo.with(Techniques.Tada)
 
 Welcome contribute your amazing animation effect. :-D
 
-#Thanks
+# Thanks
 
 - [AFViewShaker](https://github.com/ArtFeel/AFViewShaker)
 - [Animate.css](https://github.com/daneden/animate.css)
 
-#About me
+# About me
 
 A student in mainland China. 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
